### PR TITLE
Add option to read package details from file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,5 +5,6 @@ go 1.13
 require (
 	github.com/spf13/cobra v1.1.3
 	github.com/stretchr/testify v1.6.1
+	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -218,6 +218,8 @@ golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/main.go
+++ b/main.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/spf13/cobra"
 	"go/ast"
 	"go/parser"
 	"go/token"
@@ -21,6 +20,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/spf13/cobra"
 	"golang.org/x/sync/errgroup"
 )
 

--- a/main.go
+++ b/main.go
@@ -286,7 +286,7 @@ func getAllDetails(listFile string) (testFileDetailsByPackage, error) {
 }
 
 func getPackageDetails(allPackageNames map[string]*types.Nil) (testFileDetailsByPackage, error) {
-	testFileDetailByPackage := testFileDetailsByPackage{}
+	var testFileDetailByPackage testFileDetailsByPackage
 	ctx := context.Background()
 	g, ctx := errgroup.WithContext(ctx)
 	details := make(chan testFileDetailsByPackage)

--- a/main.go
+++ b/main.go
@@ -304,6 +304,10 @@ func getTestDetails(packageName string) (testFileDetailsByTest, error) {
 	if err := json.Unmarshal(out.Bytes(), goListJSON); err != nil {
 		return nil, err
 	}
+	return getFileDetails(goListJSON)
+}
+
+func getFileDetails(goListJSON *goListJSON) (testFileDetailsByTest, error) {
 	testFileDetailByTest := map[string]*testFileDetail{}
 	for _, file := range goListJSON.TestGoFiles {
 		sourceFilePath := fmt.Sprintf("%s/%s", goListJSON.Dir, file)

--- a/main_test.go
+++ b/main_test.go
@@ -4,12 +4,13 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"github.com/spf13/cobra"
-	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestVersionCommand(t *testing.T) {

--- a/main_test.go
+++ b/main_test.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -202,6 +203,43 @@ func TestReadTestDataFromStdIn(t *testing.T) {
 	assertions.Equal("--- FAIL: TestFunc3 (0.00s)\n", val.Output[3])
 	assertions.Equal(0, val.TestFunctionDetail.Line)
 	assertions.Equal(0, val.TestFunctionDetail.Col)
+}
+
+func TestGetAllDetails(t *testing.T) {
+	assertions := assert.New(t)
+	data := `{
+	"Dir": ".",
+	"ImportPath": "github.com/vakenbolt/go-test-report",
+	"Name": "main",
+	"Module": {
+		"Path": "github.com/vakenbolt/go-test-report",
+		"Main": true,
+		"Dir": "."
+	},
+	"GoFiles": [
+		"main.go"
+	],
+	"TestGoFiles": [
+		"main_test.go"
+	]
+}`
+	tmpfile, err := ioutil.TempFile("", "*.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpfile.Name())
+	if _, err = tmpfile.WriteString(data); err != nil {
+		t.Fatal(err)
+	}
+	if err = tmpfile.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	testFileDetailsByPackage, err := getAllDetails(tmpfile.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertions.Len(testFileDetailsByPackage, 1)
 }
 
 func TestGenerateReport(t *testing.T) {


### PR DESCRIPTION
This adds the option to run the `go list -json` _once_ for the entire project.

Then you can supply this file to go-test-report, using `--list` parameter.

Also runs the regular commands in parallel, but that didn't help as much...

Closes  #27