### PR TITLE
fix(passed): fix when the unit test not format normal get error class…

### DIFF
--- a/main.go
+++ b/main.go
@@ -239,6 +239,7 @@ func readTestDataFromStdIn(stdinScanner *bufio.Scanner, flags *cmdFlags, cmd *co
 			}
 			allPackageNames[goTestOutputRow.Package] = nil
 			if strings.Contains(goTestOutputRow.Output, "--- PASS:") {
+				status.Passed = true
 				goTestOutputRow.Output = strings.TrimSpace(goTestOutputRow.Output)
 			}
 			status.Output = append(status.Output, goTestOutputRow.Output)


### PR DESCRIPTION
if our unit test write as bellow: 
```
func TestPrint(t *testing.T) {
	fmt.Println(1)
}
```

we get answer
```
=== RUN   TestPrint
1
--- PASS: TestPrint (0.00s)
PASS
```
then we can classify it correct, but if it written as bellow:
```
func TestPrint(t *testing.T) {
	fmt.Print(1)
}
```
we get answer
```
=== RUN   TestPrint
1--- PASS: TestPrint (0.00s)
PASS
```
then we will get error classification