### PR TITLE
Add some tests to improve coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@ node_modules/
 go-test-report
 go-test-report.exe
 test_report.html
+coverage.out
+coverage.html
 embed_assets/embed_assets
 release_builds/
 .idea/

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,15 @@ genbuild: gencode
 gencode:
 	(cd embed_assets/;set -e;go build;./embed_assets)
 
+.PHONY: test
+test:
+	go test
+
+.PHONY: coverage
+coverage:
+	go test -coverprofile=coverage.out
+	go tool cover -html=coverage.out -o coverage.html
+
 buildall: genbuild
 	echo "Building..."
 

--- a/main.go
+++ b/main.go
@@ -323,11 +323,13 @@ func getPackageDetails(allPackageNames map[string]*types.Nil) (testFileDetailsBy
 	return testFileDetailByPackage, nil
 }
 
+var execCommand = exec.Command
+
 func getTestDetails(packageName string) (testFileDetailsByTest, error) {
 	var out bytes.Buffer
 	var cmd *exec.Cmd
 	stringReader := strings.NewReader("")
-	cmd = exec.Command("go", "list", "-json", packageName)
+	cmd = execCommand("go", "list", "-json", packageName)
 	cmd.Stdin = stringReader
 	cmd.Stdout = &out
 	err := cmd.Run()

--- a/main.go
+++ b/main.go
@@ -489,8 +489,10 @@ func parseSizeFlag(tmplData *templateData, flags *cmdFlags) error {
 	return nil
 }
 
+var osStdin = os.Stdin
+
 func checkIfStdinIsPiped() error {
-	stat, err := os.Stdin.Stat()
+	stat, err := osStdin.Stat()
 	if err != nil {
 		return err
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -287,6 +287,34 @@ func TestGetPackageDetails(t *testing.T) {
 	assertions.Len(testFileDetailsByPackage, 1)
 }
 
+func TestReportCommand(t *testing.T) {
+	assertions := assert.New(t)
+	execCommand = fakeExecCommand
+	defer func() { execCommand = exec.Command }()
+	tmpjson, err := ioutil.TempFile("", "*.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpjson.Name())
+	tmphtml, err := ioutil.TempFile("", "*.html")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmphtml.Name())
+	buffer := bytes.NewBufferString("")
+	rootCmd, _, _ := initRootCommand()
+	osStdin = tmpjson
+	defer func() { osStdin = os.Stdin }()
+	rootCmd.SetIn(tmpjson)
+	rootCmd.SetOut(buffer)
+	rootCmd.SetArgs([]string{"--output", tmphtml.Name()})
+	rootCmdErr := rootCmd.Execute()
+	assertions.Nil(rootCmdErr)
+	output, readErr := ioutil.ReadAll(buffer)
+	assertions.Nil(readErr)
+	assertions.Contains(string(output), "[go-test-report] finished")
+}
+
 func TestGenerateReport(t *testing.T) {
 	assertions := assert.New(t)
 	tmplData := &templateData{


### PR DESCRIPTION
* Add test for generateReport with `os.stdin` mock
* Add test for getPackageDetails with `exec` mock

```
go test -cover
```

BEFORE
`overage: 63.8% of statements`

AFTER
`coverage: 86.2% of statements`

See coverage.html for details, after "make coverage"